### PR TITLE
Buscar salas

### DIFF
--- a/src/main/java/br/com/jackson/stop/compartilhado/handler/ValidationExceptionResponse.java
+++ b/src/main/java/br/com/jackson/stop/compartilhado/handler/ValidationExceptionResponse.java
@@ -25,11 +25,4 @@ public class ValidationExceptionResponse {
     return ocorridoEm;
   }
 
-  @Override
-  public String toString() {
-    return "ValidationExceptionResponse{" +
-            "erros=" + erros +
-            ", ocorridoEm='" + ocorridoEm + '\'' +
-            '}';
-  }
 }

--- a/src/main/java/br/com/jackson/stop/sala/CategoriasResponse.java
+++ b/src/main/java/br/com/jackson/stop/sala/CategoriasResponse.java
@@ -1,0 +1,13 @@
+package br.com.jackson.stop.sala;
+
+public class CategoriasResponse {
+  private final String nomeCategoria;
+
+  public CategoriasResponse(Categoria categoria) {
+    this.nomeCategoria = categoria.getNome();
+  }
+
+    public String getNomeCategoria() {
+        return nomeCategoria;
+    }
+}

--- a/src/main/java/br/com/jackson/stop/sala/DetalheDaSalaResponse.java
+++ b/src/main/java/br/com/jackson/stop/sala/DetalheDaSalaResponse.java
@@ -1,0 +1,27 @@
+package br.com.jackson.stop.sala;
+
+import java.util.List;
+
+public class DetalheDaSalaResponse {
+  private final TempoJogo tempoJogo;
+  private final List<CategoriasResponse> categorias;
+  private final List<String> letras;
+
+  public DetalheDaSalaResponse(Sala sala) {
+    this.tempoJogo = sala.getTempoJogo();
+    this.categorias = sala.getCategorias().stream().map(CategoriasResponse::new).toList();
+    this.letras = sala.getLetras();
+  }
+
+  public TempoJogo getTempoJogo() {
+    return tempoJogo;
+  }
+
+  public List<CategoriasResponse> getCategorias() {
+    return categorias;
+  }
+
+  public List<String> getLetras() {
+    return letras;
+  }
+}

--- a/src/main/java/br/com/jackson/stop/sala/NovaSalaRequest.java
+++ b/src/main/java/br/com/jackson/stop/sala/NovaSalaRequest.java
@@ -14,8 +14,8 @@ import java.util.List;
 @ICP(8.5)
 @LetrasCompativeisRodadas
 public record NovaSalaRequest(//3.5
-        @NotNull @Range(min = 1, max = 12) int rodadas,
-        @NotNull @Range(min = 1, max = 12) int maximoJogadores,
+        @NotNull @Range(min = 4, max = 12) int rodadas,
+        @NotNull @Range(min = 4, max = 12) int maximoJogadores,
         String senha,
         @NotNull @NotEmpty @UniqueElements List<String> categorias,
         @NotNull @NotEmpty @UniqueElements @LetrasPermitidas List< String> letras,
@@ -37,7 +37,7 @@ public record NovaSalaRequest(//3.5
     //1
     var novaSala = new Sala(rodadas, maximoJogadores, listaCategorias, letras, tempoJogo);
     //1
-    if (StringUtils.hasText(senha)) {
+    if (StringUtils.hasText(this.senha)) {
         novaSala.adicionaSenha(this.senha);
     }
     return novaSala;

--- a/src/main/java/br/com/jackson/stop/sala/Sala.java
+++ b/src/main/java/br/com/jackson/stop/sala/Sala.java
@@ -18,7 +18,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Table(name = "salas")
-@ICP(6.0)
+@ICP(7)
 public class Sala {
 
   // 0.5
@@ -140,6 +140,7 @@ public class Sala {
   }
 
   public boolean salaDisponivel() {
+    //1
     return this.jogadoresAtuais < this.maximoJogadores;
   }
 }

--- a/src/main/java/br/com/jackson/stop/sala/Sala.java
+++ b/src/main/java/br/com/jackson/stop/sala/Sala.java
@@ -8,6 +8,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -35,6 +36,9 @@ public class Sala {
   @Column(nullable = false)
   @Range(min = 1, max = 12)
   private int maximoJogadores;
+
+  @Max(12)
+  private Integer jogadoresAtuais = 0;
 
   // 0.5
   private String senha;
@@ -65,14 +69,14 @@ public class Sala {
   public Sala() {}
 
   public Sala(
-      @NotNull @Range(min = 1, max = 12) int rodadas,
-      @NotNull @Range(min = 1, max = 12) int maximoJogadores,
+      @NotNull @Range(min = 4, max = 12) int rodadas,
+      @NotNull @Range(min = 4, max = 12) int maximoJogadores,
       @NotNull @NotEmpty @UniqueElements List<Categoria> categorias,
       @NotNull @NotEmpty @LetrasPermitidas @UniqueElements List<String> letras,
       @NotNull TempoJogo tempoJogo) {
-    Assert.state(rodadas >= 1 && rodadas <= 12, "Rodadas devem estar entre 1 e 12");
+    Assert.state(rodadas >= 4 && rodadas <= 12, "Rodadas devem estar entre 1 e 12");
     Assert.state(
-        maximoJogadores >= 1 && maximoJogadores <= 12,
+        maximoJogadores >= 4 && maximoJogadores <= 12,
         "Maximo de jogadores devem estar entre 1 e 12");
     Assert.notNull(categorias, "Categorias não pode ser nula");
     Assert.state(!categorias.isEmpty(), "Categorias não pode ser nula");
@@ -122,12 +126,20 @@ public class Sala {
     return id;
   }
 
+  public Integer getJogadoresAtuais() {
+    return jogadoresAtuais;
+  }
+
   // quando uma senha é setada, automaticamente a sala fica privada
   public void adicionaSenha(String senha) {
-    Assert.state(this.senha != null, "Sala já possui senha cadastrada");
+    Assert.state(this.senha == null, "Sala já possui senha cadastrada");
     Assert.state(StringUtils.hasText(senha), "Senha não pode ser nula ou vazia");
 
     this.senha = senha;
     this.privada = true;
+  }
+
+  public boolean salaDisponivel() {
+    return this.jogadoresAtuais < this.maximoJogadores;
   }
 }

--- a/src/main/java/br/com/jackson/stop/sala/SalaController.java
+++ b/src/main/java/br/com/jackson/stop/sala/SalaController.java
@@ -3,14 +3,14 @@ package br.com.jackson.stop.sala;
 import br.com.jackson.stop.compartilhado.anotacoes.ICP;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RestController
 @RequestMapping("/api/salas")
@@ -42,5 +42,21 @@ public class SalaController {
             .toUri();
 
     return ResponseEntity.created(locationURI).build();
+  }
+
+  @GetMapping
+  public ResponseEntity<?> buscarDisponiveis() {
+    var salasDisponiveis = salaRepository.findAll().stream().filter(Sala::salaDisponivel).toList();
+    var salasResponses = salasDisponiveis.stream().map(SalasResponse::new).toList();
+    return ResponseEntity.ok(salasResponses);
+  }
+
+  @GetMapping(path = "/{id}")
+  public ResponseEntity<?> buscar(@PathVariable Long id) {
+    var sala =
+        salaRepository
+            .findById(id)
+            .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Sala não encontrada"));
+    return ResponseEntity.ok(new DetalheDaSalaResponse(sala));
   }
 }

--- a/src/main/java/br/com/jackson/stop/sala/SalaController.java
+++ b/src/main/java/br/com/jackson/stop/sala/SalaController.java
@@ -9,12 +9,13 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+import java.util.List;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RestController
 @RequestMapping("/api/salas")
-@ICP(4)
+@ICP(6)
 public class SalaController {
 
   // 2
@@ -45,18 +46,20 @@ public class SalaController {
   }
 
   @GetMapping
-  public ResponseEntity<?> buscarDisponiveis() {
+  public ResponseEntity<List<SalasResponse>> buscarDisponiveis() {
     var salasDisponiveis = salaRepository.findAll().stream().filter(Sala::salaDisponivel).toList();
+    // 1
     var salasResponses = salasDisponiveis.stream().map(SalasResponse::new).toList();
     return ResponseEntity.ok(salasResponses);
   }
 
   @GetMapping(path = "/{id}")
-  public ResponseEntity<?> buscar(@PathVariable Long id) {
+  public ResponseEntity<DetalheDaSalaResponse> buscar(@PathVariable Long id) {
     var sala =
         salaRepository
             .findById(id)
             .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Sala não encontrada"));
+    // 1
     return ResponseEntity.ok(new DetalheDaSalaResponse(sala));
   }
 }

--- a/src/main/java/br/com/jackson/stop/sala/SalasResponse.java
+++ b/src/main/java/br/com/jackson/stop/sala/SalasResponse.java
@@ -1,0 +1,44 @@
+package br.com.jackson.stop.sala;
+
+public class SalasResponse {
+
+  private final Long id;
+  private final int numeroMaximoParticipantes;
+  private final int numeroParticipantesAtual;
+  private final int quantidadeCategorias;
+  private final int quantidadeRodadas;
+  private final boolean privada;
+
+  public SalasResponse(Sala sala) {
+    this.id = sala.getId();
+    this.numeroMaximoParticipantes = sala.getMaximoJogadores();
+    this.numeroParticipantesAtual = sala.getJogadoresAtuais();
+    this.quantidadeCategorias = sala.getCategorias().size();
+    this.quantidadeRodadas = sala.getRodadas();
+    this.privada = sala.isPrivada();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public int getNumeroMaximoParticipantes() {
+    return numeroMaximoParticipantes;
+  }
+
+  public int getNumeroParticipantesAtual() {
+    return numeroParticipantesAtual;
+  }
+
+  public int getQuantidadeCategorias() {
+    return quantidadeCategorias;
+  }
+
+  public int getQuantidadeRodadas() {
+    return quantidadeRodadas;
+  }
+
+  public boolean isPrivada() {
+    return privada;
+  }
+}

--- a/src/main/resources/db/migration/V2__Adicionar_Jogadores_Atuais_Salas.sql
+++ b/src/main/resources/db/migration/V2__Adicionar_Jogadores_Atuais_Salas.sql
@@ -1,0 +1,2 @@
+ALTER TABLE salas
+    ADD jogadores_atuais INTEGER;

--- a/src/test/java/br/com/jackson/stop/compartilhado/anotacoes/LetrasCompativeisRodadasTest.java
+++ b/src/test/java/br/com/jackson/stop/compartilhado/anotacoes/LetrasCompativeisRodadasTest.java
@@ -1,7 +1,5 @@
 package br.com.jackson.stop.compartilhado.anotacoes;
 
-import br.com.jackson.stop.sala.NovaSalaRequest;
-import br.com.jackson.stop.sala.TempoJogo;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Label;
 import net.jqwik.api.Property;
@@ -13,6 +11,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import java.util.List;
 
+import static br.com.jackson.stop.sala.SalaFactory.criaNovaSalaRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LetrasCompativeisRodadasTest {
@@ -22,36 +21,28 @@ class LetrasCompativeisRodadasTest {
   @Test
   @DisplayName("Deve validar quando a quantidade de letras for igual ao numero de rodadas")
   void teste1() {
-    var request = criaNovaSalaRequest(2, List.of("A", "B"));
+    var request = criaNovaSalaRequest("senha", 4, List.of("A", "B", "C", "D"));
 
     assertEquals(0, validator.validate(request).size());
   }
 
-  @Property(tries = 12)
+  @Property(tries = 8)
   @Label("Deve validar quando a quantidade de rodadas for menor que a quantidade de letras")
-  void teste2(@ForAll @IntRange(min = 1, max = 11) int rodadas) {
+  void teste2(@ForAll @IntRange(min = 4, max = 11) int rodadas) {
     var request =
         criaNovaSalaRequest(
-            rodadas, List.of("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"));
+            "senha", rodadas, List.of("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"));
 
     assertEquals(0, validator.validate(request).size());
   }
 
-  @Property(tries = 11)
+  @Property(tries = 8)
   @Label("Não deve validar quando a quantidade de rodadas for maior que a quantidade de letras")
-  void teste3(@ForAll @IntRange(min = 2, max = 12) int rodadas) {
-    var request = criaNovaSalaRequest(rodadas, List.of("A"));
+  void teste3(@ForAll @IntRange(min = 4, max = 12) int rodadas) {
+    var request = criaNovaSalaRequest("senha", rodadas, List.of("A"));
 
     var validacao = validator.validate(request);
 
     assertEquals(1, validacao.size());
-    assertEquals(
-        "A quantidade de letras deve ser maior ou igual ao número de rodadas",
-        validacao.iterator().next().getMessage());
-  }
-
-  private NovaSalaRequest criaNovaSalaRequest(int rodadas, List<String> letras) {
-    return new NovaSalaRequest(
-        rodadas, 10, "senha", List.of("Categoria 1", "Categoria 2"), letras, TempoJogo.MEDIO);
   }
 }

--- a/src/test/java/br/com/jackson/stop/sala/NovaSalaRequestTest.java
+++ b/src/test/java/br/com/jackson/stop/sala/NovaSalaRequestTest.java
@@ -27,7 +27,7 @@ class NovaSalaRequestTest {
     @Test
     @DisplayName("Deve validar quando a quantidade de letras é igual com as rodadas")
     void teste1() {
-      var request = criaNovaSalaRequest("senha",2, List.of("A", "B"));
+      var request = criaNovaSalaRequest("senha", 2, List.of("A", "B"));
 
       assertTrue(request.letrasCompativeisComRodadas());
     }
@@ -35,7 +35,7 @@ class NovaSalaRequestTest {
     @Test
     @DisplayName("Deve validar quando a quantidade de letras é uma maior que as rodadas")
     void teste2() {
-      var request = criaNovaSalaRequest("senha",2, List.of("A", "B", "C"));
+      var request = criaNovaSalaRequest("senha", 2, List.of("A", "B", "C"));
 
       assertTrue(request.letrasCompativeisComRodadas());
     }
@@ -43,7 +43,7 @@ class NovaSalaRequestTest {
     @Test
     @DisplayName("Não deve validar quando a quantidade de letras é uma menor que as rodadas")
     void teste3() {
-      var request = criaNovaSalaRequest("senha",2, List.of("A"));
+      var request = criaNovaSalaRequest("senha", 2, List.of("A"));
 
       assertFalse(request.letrasCompativeisComRodadas());
     }
@@ -57,7 +57,7 @@ class NovaSalaRequestTest {
     void teste1(
         @ForAll @IntRange(min = 1, max = 11) int rodadas,
         @ForAll @Size(12) @UniqueElements List<@UpperChars @StringLength(1) String> letras) {
-      var request = criaNovaSalaRequest("senha",rodadas, letras);
+      var request = criaNovaSalaRequest("senha", rodadas, letras);
 
       assertTrue(request.letrasCompativeisComRodadas());
     }
@@ -67,7 +67,7 @@ class NovaSalaRequestTest {
     void teste2(
         @ForAll @IntRange(min = 2, max = 12) int rodadas,
         @ForAll @Size(1) @UniqueElements List<@UpperChars @StringLength(1) String> letras) {
-      var request = criaNovaSalaRequest("senha",rodadas, letras);
+      var request = criaNovaSalaRequest("senha", rodadas, letras);
 
       assertFalse(request.letrasCompativeisComRodadas());
     }
@@ -84,7 +84,7 @@ class NovaSalaRequestTest {
       when(categoriaRepositoryMock.existsByNome(CATEGORIA_1)).thenReturn(false);
       when(categoriaRepositoryMock.save(categoria)).thenReturn(categoria);
 
-      var request = criaNovaSalaRequest("senha", 2, List.of("A", "B"));
+      var request = criaNovaSalaRequest("senha", 4, List.of("A", "B", "C", "D"));
 
       var sala = request.toSala(categoriaRepositoryMock);
       Assertions.assertAll(
@@ -105,7 +105,7 @@ class NovaSalaRequestTest {
       when(categoriaRepositoryMock.existsByNome(CATEGORIA_1)).thenReturn(false);
       when(categoriaRepositoryMock.save(categoria)).thenReturn(categoria);
 
-      var request = criaNovaSalaRequest(null, 2, List.of("A", "B"));
+      var request = criaNovaSalaRequest(null, 4, List.of("A", "B", "C", "D"));
 
       var sala = request.toSala(categoriaRepositoryMock);
       Assertions.assertAll(
@@ -125,7 +125,7 @@ class NovaSalaRequestTest {
       when(categoriaRepositoryMock.existsByNome(CATEGORIA_1)).thenReturn(true);
       when(categoriaRepositoryMock.findByNome(CATEGORIA_1)).thenReturn(Optional.of(categoria));
 
-      var request = criaNovaSalaRequest("senha", 2, List.of("A", "B"));
+      var request = criaNovaSalaRequest("senha", 4, List.of("A", "B", "C", "D"));
 
       var sala = request.toSala(categoriaRepositoryMock);
       Assertions.assertAll(

--- a/src/test/java/br/com/jackson/stop/sala/SalaControllerTest.java
+++ b/src/test/java/br/com/jackson/stop/sala/SalaControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.jackson.stop.sala;
 
+import br.com.jackson.stop.compartilhado.handler.ExceptionsHandlerResponse;
 import br.com.jackson.stop.compartilhado.handler.ValidationExceptionResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,13 +16,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import javax.transaction.Transactional;
 import java.util.List;
 
-import static br.com.jackson.stop.sala.SalaFactory.criaNovaSalaRequest;
+import static br.com.jackson.stop.sala.SalaFactory.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -130,6 +131,109 @@ class SalaControllerTest {
                   "Apenas letras maiusculas e unicas de A a Z sao permitidas",
                   resposta.getErros().get("letras").iterator().next()),
           () -> assertEquals(2, resposta.getErros().size()),
+          () -> assertNotNull(resposta.getOcorridoEm()));
+    }
+  }
+
+  @Nested
+  class MetodoBuscarDisponiveisTest {
+    @Test
+    @DisplayName("Deve retornar uma lista de salas disponíveis")
+    void teste1() throws Exception {
+      var sala1 = criaSalaSemSenha();
+      var sala2 = criaSalaComSenha();
+      salaRepository.saveAll(List.of(sala1, sala2));
+
+      mockMvc
+          .perform(get("/api/salas"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$[0].id").value(sala1.getId().intValue()))
+          .andExpect(jsonPath("$[1].id").value(sala2.getId().intValue()))
+          .andExpect(jsonPath("$[0].numeroMaximoParticipantes").value(sala1.getMaximoJogadores()))
+          .andExpect(jsonPath("$[1].numeroMaximoParticipantes").value(sala2.getMaximoJogadores()))
+          .andExpect(jsonPath("$[0].numeroParticipantesAtual").value(sala1.getJogadoresAtuais()))
+          .andExpect(jsonPath("$[1].numeroParticipantesAtual").value(sala2.getJogadoresAtuais()))
+          .andExpect(jsonPath("$[0].quantidadeCategorias").value(sala1.getCategorias().size()))
+          .andExpect(jsonPath("$[1].quantidadeCategorias").value(sala2.getCategorias().size()))
+          .andExpect(jsonPath("$[0].quantidadeRodadas").value(sala1.getRodadas()))
+          .andExpect(jsonPath("$[1].quantidadeRodadas").value(sala2.getRodadas()))
+          .andExpect(jsonPath("$[0].privada").value(false))
+          .andExpect(jsonPath("$[1].privada").value(true));
+
+      // não fiz assert transformando o response na classe de DTO de resposta, pq precisaria criar
+      // um construtor vazio na clase,
+      // não sei se isso é muito legal, mudar o código para o teste ficar melhor
+    }
+
+    @Test
+    @DisplayName("Deve retornar uma lista vazia quando não há salas disponíveis")
+    void teste2() throws Exception {
+
+      mockMvc
+          .perform(get("/api/salas"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$").isEmpty());
+    }
+  }
+
+  @Nested
+  class MetodoBuscarTest {
+    @Test
+    @DisplayName("Deve retornar os dados de uma sala sem senha, status 200")
+    void teste1() throws Exception {
+      var sala = criaSalaSemSenha();
+      salaRepository.save(sala);
+
+      mockMvc
+          .perform(get("/api/salas/" + sala.getId()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.tempoJogo").value(sala.getTempoJogo().toString()))
+          .andExpect(
+              jsonPath("$.categorias[0].nomeCategoria")
+                  .value(sala.getCategorias().get(0).getNome()))
+          .andExpect(jsonPath("$.letras[0]").value(sala.getLetras().get(0)))
+          .andExpect(jsonPath("$.letras[1]").value(sala.getLetras().get(1)))
+          .andExpect(jsonPath("$.letras[2]").value(sala.getLetras().get(2)))
+          .andExpect(jsonPath("$.letras[3]").value(sala.getLetras().get(3)));
+    }
+
+    @Test
+    @DisplayName("Deve retornar os dados de uma uma sala com senha (privada), status 200")
+    void teste2() throws Exception {
+      var sala = criaSalaComSenha();
+      salaRepository.save(sala);
+
+      mockMvc
+          .perform(get("/api/salas/" + sala.getId()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.tempoJogo").value(sala.getTempoJogo().toString()))
+          .andExpect(
+              jsonPath("$.categorias[0].nomeCategoria")
+                  .value(sala.getCategorias().get(0).getNome()))
+          .andExpect(jsonPath("$.letras[0]").value(sala.getLetras().get(0)))
+          .andExpect(jsonPath("$.letras[1]").value(sala.getLetras().get(1)))
+          .andExpect(jsonPath("$.letras[2]").value(sala.getLetras().get(2)))
+          .andExpect(jsonPath("$.letras[3]").value(sala.getLetras().get(3)));
+    }
+
+    @Test
+    @DisplayName("Não deve retornar os dados de uma sala quando a sala não existe, status 404")
+    void teste3() throws Exception {
+      var response =
+          mockMvc
+              .perform(get("/api/salas/1"))
+              .andExpect(status().isNotFound())
+              .andExpect(jsonPath("$.mensagem").value("Sala não encontrada"))
+              .andExpect(jsonPath("$.ocorridoEm").exists())
+              .andReturn()
+              .getResponse()
+              .getContentAsString(UTF_8);
+
+      var resposta =
+          (ExceptionsHandlerResponse) fromJson(response, ExceptionsHandlerResponse.class);
+
+      assertAll(
+          () -> assertEquals("Sala não encontrada", resposta.getMensagem()),
           () -> assertNotNull(resposta.getOcorridoEm()));
     }
   }

--- a/src/test/java/br/com/jackson/stop/sala/SalaControllerTest.java
+++ b/src/test/java/br/com/jackson/stop/sala/SalaControllerTest.java
@@ -39,7 +39,7 @@ class SalaControllerTest {
     @Test
     @DisplayName("Deve cadastrar uma sala com request válido com senha")
     void teste1() throws Exception {
-      var request = criaNovaSalaRequest("senha", 3, List.of("A", "B", "C"));
+      var request = criaNovaSalaRequest("senha", 4, List.of("A", "B", "C", "D"));
       mockMvc
           .perform(post("/api/salas").contentType(APPLICATION_JSON).content(toJson(request)))
           .andExpect(status().isCreated())
@@ -63,7 +63,7 @@ class SalaControllerTest {
     @Test
     @DisplayName("Deve cadastrar uma sala com request válido sem senha")
     void teste2() throws Exception {
-      var request = criaNovaSalaRequest(null, 3, List.of("A", "B", "C"));
+      var request = criaNovaSalaRequest(null, 4, List.of("A", "B", "C", "D"));
       mockMvc
           .perform(post("/api/salas").contentType(APPLICATION_JSON).content(toJson(request)))
           .andExpect(status().isCreated())
@@ -86,7 +86,7 @@ class SalaControllerTest {
     @Test
     @DisplayName("Não deve cadastrar uma sala com request inválido com menos letras do que rodadas")
     void teste3() throws Exception {
-      var request = criaNovaSalaRequest(null, 4, List.of("A", "B", "C"));
+      var request = criaNovaSalaRequest(null, 5, List.of("A", "B", "C", "D"));
       var response =
           mockMvc
               .perform(post("/api/salas").contentType(APPLICATION_JSON).content(toJson(request)))
@@ -102,7 +102,7 @@ class SalaControllerTest {
           () -> assertTrue(salaRepository.findAll().isEmpty()),
           () ->
               assertEquals(
-                  "A quantidade de letras deve ser maior ou igual ao número de rodadas",
+                  "A quantidade de letras deve ser maior ou igual ao numero de rodadas",
                   resposta.getErros().get("Erro na requisição").iterator().next()),
           () -> assertEquals(1, resposta.getErros().size()),
           () -> assertNotNull(resposta.getOcorridoEm()));
@@ -111,7 +111,7 @@ class SalaControllerTest {
     @Test
     @DisplayName("Não deve cadastrar uma sala com request com menos letras inválidas")
     void teste4() throws Exception {
-      var request = criaNovaSalaRequest(null, 3, List.of("A", "0", "~"));
+      var request = criaNovaSalaRequest(null, 4, List.of("A", "0", "~", "!"));
       var response =
           mockMvc
               .perform(post("/api/salas").contentType(APPLICATION_JSON).content(toJson(request)))
@@ -127,9 +127,9 @@ class SalaControllerTest {
           () -> assertTrue(salaRepository.findAll().isEmpty()),
           () ->
               assertEquals(
-                  "Apenas letras maiúsculas únicas de A a Z são permitidas",
+                  "Apenas letras maiusculas e unicas de A a Z sao permitidas",
                   resposta.getErros().get("letras").iterator().next()),
-          () -> assertEquals(1, resposta.getErros().size()),
+          () -> assertEquals(2, resposta.getErros().size()),
           () -> assertNotNull(resposta.getOcorridoEm()));
     }
   }

--- a/src/test/java/br/com/jackson/stop/sala/SalaFactory.java
+++ b/src/test/java/br/com/jackson/stop/sala/SalaFactory.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public class SalaFactory {
   public static final String CATEGORIA_1 = "Categoria 1";
+  public static final String CATEGORIA_2 = "Categoria 2";
 
   public static NovaSalaRequest criaNovaSalaRequest(
       String senha, int rodadas, List<String> letras) {
@@ -13,5 +14,17 @@ public class SalaFactory {
   public static Sala criaSalaSemSenha() {
     return new Sala(
         4, 10, List.of(new Categoria(CATEGORIA_1)), List.of("A", "B", "C", "D"), TempoJogo.MEDIO);
+  }
+
+  public static Sala criaSalaComSenha() {
+    var sala =
+        new Sala(
+            4,
+            10,
+            List.of(new Categoria(CATEGORIA_2)),
+            List.of("A", "B", "C", "D"),
+            TempoJogo.MEDIO);
+    sala.adicionaSenha("senha");
+    return sala;
   }
 }

--- a/src/test/java/br/com/jackson/stop/sala/SalaFactory.java
+++ b/src/test/java/br/com/jackson/stop/sala/SalaFactory.java
@@ -11,6 +11,7 @@ public class SalaFactory {
   }
 
   public static Sala criaSalaSemSenha() {
-    return new Sala(2, 10, List.of(new Categoria(CATEGORIA_1)), List.of("A", "B"), TempoJogo.MEDIO);
+    return new Sala(
+        4, 10, List.of(new Categoria(CATEGORIA_1)), List.of("A", "B", "C", "D"), TempoJogo.MEDIO);
   }
 }

--- a/src/test/java/br/com/jackson/stop/sala/SalaTest.java
+++ b/src/test/java/br/com/jackson/stop/sala/SalaTest.java
@@ -1,11 +1,13 @@
 package br.com.jackson.stop.sala;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static br.com.jackson.stop.sala.SalaFactory.criaSalaComSenha;
 import static br.com.jackson.stop.sala.SalaFactory.criaSalaSemSenha;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 class SalaTest {
 
@@ -13,12 +15,51 @@ class SalaTest {
   class MetodoAdicionaSenhaTest {
 
     @Test
+    @DisplayName("Deve adicionar senha a sala")
     void teste1() {
       var sala = criaSalaSemSenha();
       sala.adicionaSenha("123");
 
       assertEquals("123", sala.getSenha());
       assertTrue(sala.isPrivada());
+    }
+  }
+
+  @Nested
+  class MetodoSalaDisponivelTest {
+
+    @Test
+    @DisplayName("Deve retornar true se a sala sem senha estiver disponivel")
+    void teste1() {
+      var sala = criaSalaSemSenha();
+
+      assertTrue(sala.salaDisponivel());
+    }
+
+    @Test
+    @DisplayName("Deve retornar true se a sala com senha estiver disponivel")
+    void teste2() {
+      var sala = criaSalaComSenha();
+
+      assertTrue(sala.salaDisponivel());
+    }
+
+    @Test
+    @DisplayName("Deve retornar false se a sala com senha estiver ocupada")
+    void teste3() {
+      var sala = criaSalaComSenha();
+      setField(sala, "jogadoresAtuais", sala.getMaximoJogadores());
+
+      assertFalse(sala.salaDisponivel());
+    }
+
+    @Test
+    @DisplayName("Deve retornar false se a sala sem senha estiver ocupada")
+    void teste4() {
+      var sala = criaSalaSemSenha();
+      setField(sala, "jogadoresAtuais", sala.getMaximoJogadores());
+
+      assertFalse(sala.salaDisponivel());
     }
   }
 }


### PR DESCRIPTION
## Motivo

O jogo acontece dentro de uma sala. É possível buscar salas livres ou privadas.

## Necessidades

Ser possível listar salas que ainda tem disponibilidade de entrara para jogar, ou seja, salas que não estão com a capacidade total ocupada.
Além de mostrar todas as salas disponíveis, ao clicar numa sala específica, aparecem os dados dessa sala ao lado.

## Usuário a ser impactado

Jogador

## O que é obrigatório ?
- na listagem das salas devem aparecer as seguintes informações:
   . id da sala
   . numero máximo de participantes
   . numero de participantes atual
   . quantidade de categorias
   . rodadas
   . se é privado ou não

- nos detalhes da sala devem conter as informações:
   . tempo (se é rápido, médio ou lento)
   . categorias
   . letras


## Restrições 
na busca de todas as salas, mostrar somente salas disponíveis, sem estarem completamente ocupadas

## O que é opcional ?

## Resultado esperado dentro do sistema
endpoint com listagem de salas disponiveis para jogar e endpoint com detalhes de uma sala específica

## Retorno esperado para a aplicação cliente
 200 com os dados das salas
## E se der alguma coisa errado?
* Status 404 caso sala não exista
* Status 400 com os erros que aconteceram
* Status 500 em caso de algum problema inesperado